### PR TITLE
Fix GitHub Actions test summary workflow failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,7 +200,7 @@ jobs:
       with:
         files: |
           test-artifacts/**/TEST-*.xml
-          test-artifacts/**/*.xml
+          test-artifacts/**/test-results/**/*.xml
         check_name: "Test Results Summary"
         comment_mode: always
         fail_on: "test failures"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,6 +185,7 @@ jobs:
 
     permissions:
       checks: write
+      pull-requests: write
 
     if: always()
 


### PR DESCRIPTION
The EnricoMi/publish-unit-test-result-action was failing because it was trying to process JaCoCo coverage reports (jacocoTestReport.xml) as test result files. Updated the file pattern to only include actual test result XML files and exclude coverage reports.