### PR TITLE
Add 7-day Dependabot cooldown for all dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 7
     groups:
       all-dependencies:
         patterns:
@@ -12,6 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       all-actions:
         patterns:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
         path: build/test-results/test/*.xml
         reporter: java-junit
         fail-on-error: false
+        use-actions-summary: false
 
     - name: Upload test results
       if: always()


### PR DESCRIPTION
Add a 7-day cooldown to every Dependabot update block so new dependency versions settle for a week before an update PR is opened.